### PR TITLE
feat: add tab for request timings

### DIFF
--- a/src/entrypoints/devtools-panel/request-details/RequestDetails.tsx
+++ b/src/entrypoints/devtools-panel/request-details/RequestDetails.tsx
@@ -8,14 +8,15 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import HeadersTab from "@/entrypoints/devtools-panel/request-details/tabs/headers/HeadersTab";
-import RequestTab from "@/entrypoints/devtools-panel/request-details/tabs/request/RequestTab";
 import { useVisibleItems } from "@/hooks/useVisibleItems";
 import { cn } from "@/lib/utils";
 import { AtlassianEntry } from "@/types/atlassian";
 import { ChevronsRight, X } from "lucide-react";
 import { useState } from "react";
+import HeadersTab from "./tabs/headers/HeadersTab";
+import RequestTab from "./tabs/request/RequestTab";
 import ResponseTab from "./tabs/response/ResponseTab";
+import TimingsTab from "./tabs/timings/TimingsTab";
 
 export interface RequestDetailsProps {
   request: AtlassianEntry;
@@ -39,6 +40,10 @@ const TABS: Tab[] = [
   {
     label: "Response",
     value: "response",
+  },
+  {
+    label: "Timings",
+    value: "timings",
   },
 ];
 
@@ -135,6 +140,9 @@ function RequestDetails({ request, onCloseRequest }: RequestDetailsProps) {
       </TabsContent>
       <TabsContent value="response" className="flex h-full w-full flex-col gap-0 overflow-auto p-0">
         <ResponseTab request={request} />
+      </TabsContent>
+      <TabsContent value="timings" className="flex h-full w-full flex-col gap-0 overflow-auto p-0">
+        <TimingsTab request={request} />
       </TabsContent>
     </Tabs>
   );

--- a/src/entrypoints/devtools-panel/request-details/tabs/headers/HeadersTab.tsx
+++ b/src/entrypoints/devtools-panel/request-details/tabs/headers/HeadersTab.tsx
@@ -137,7 +137,7 @@ function HeadersTab({ request }: HeadersTabProps) {
               <TableBody>
                 {generalDetails.map(({ name, value }) => (
                   <TableRow key={name} className="border-none bg-background hover:bg-background">
-                    <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pb-1">{name}</TableHead>
+                    <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pr-1 pb-1">{name}</TableHead>
                     <TableCell className="h-6 p-0 pb-1 break-all whitespace-normal">{value}</TableCell>
                   </TableRow>
                 ))}
@@ -157,7 +157,7 @@ function HeadersTab({ request }: HeadersTabProps) {
                 {contextDetails.length === 0 && <p>No invocation context for this request.</p>}
                 {contextDetails.map(({ name, value }) => (
                   <TableRow key={name} className="border-none bg-background hover:bg-background">
-                    <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pb-1">{name}</TableHead>
+                    <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pr-1 pb-1">{name}</TableHead>
                     <TableCell className="h-6 p-0 pb-1 break-all whitespace-normal">{value}</TableCell>
                   </TableRow>
                 ))}
@@ -180,7 +180,7 @@ function HeadersTab({ request }: HeadersTabProps) {
                   <TableBody>
                     {Object.entries(request.parsedResponse.headers).map(([name, value]) => (
                       <TableRow key={name} className="border-none bg-background hover:bg-background">
-                        <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pb-1">{name}</TableHead>
+                        <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pr-1 pb-1">{name}</TableHead>
                         <TableCell className="h-6 p-0 pb-1 wrap-break-word whitespace-normal">{value}</TableCell>
                       </TableRow>
                     ))}
@@ -205,7 +205,7 @@ function HeadersTab({ request }: HeadersTabProps) {
                   <TableBody>
                     {Object.entries(request.parsedRequest.headers).map(([name, value]) => (
                       <TableRow key={name} className="border-none bg-background hover:bg-background">
-                        <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pb-1">{name}</TableHead>
+                        <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pr-1 pb-1">{name}</TableHead>
                         <TableCell className="h-6 p-0 pb-1 wrap-break-word whitespace-normal">{value}</TableCell>
                       </TableRow>
                     ))}

--- a/src/entrypoints/devtools-panel/request-details/tabs/timings/TimingsTab.tsx
+++ b/src/entrypoints/devtools-panel/request-details/tabs/timings/TimingsTab.tsx
@@ -1,0 +1,99 @@
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { AtlassianEntry } from "@/types/atlassian";
+import { formatDuration } from "@/utils/time-utils";
+import { CircleQuestionMark } from "lucide-react";
+import { ReactNode } from "react";
+
+export interface TimingsTabProps {
+  request: AtlassianEntry;
+}
+
+interface RequestTiming {
+  name: string;
+  helpMessage?: string;
+  value: ReactNode;
+}
+
+function getRequestTimings(entry: AtlassianEntry): RequestTiming[] {
+  return [
+    {
+      name: "Blocked",
+      helpMessage: "Time spent in a queue waiting for a network connection.",
+      value: formatDuration(entry.timings.blocked, 2, "-"),
+    },
+    {
+      name: "DNS",
+      helpMessage: "Time taken to resolve a host name.",
+      value: formatDuration(entry.timings.dns, 2, "-"),
+    },
+    {
+      name: "Connect",
+      helpMessage: "Time taken to create a TCP connection.",
+      value: formatDuration(entry.timings.connect, 2, "-"),
+    },
+    {
+      name: "TLS",
+      helpMessage: "Time taken for SSL/TLS negotiation.",
+      value: formatDuration(entry.timings.ssl, 2, "-"),
+    },
+    {
+      name: "Send",
+      helpMessage: "Time taken to send the HTTP request to the server.",
+      value: formatDuration(entry.timings.send, 2, "-"),
+    },
+    {
+      name: "Wait",
+      helpMessage: "Time spent waiting for a response from the server.",
+      value: formatDuration(entry.timings.wait, 2, "-"),
+    },
+    {
+      name: "Receive",
+      helpMessage: "Time taken to read the entire response from the server (or cache).",
+      value: formatDuration(entry.timings.receive, 2, "-"),
+    },
+    {
+      name: "Total",
+      value: formatDuration(entry.parsedResponse.duration),
+    },
+  ];
+}
+
+function TimingsTab({ request }: TimingsTabProps) {
+  const timings = getRequestTimings(request);
+  return (
+    <div className="flex flex-col gap-0 p-2">
+      <Table className="text-xs">
+        <TableBody>
+          {timings.map(({ name, helpMessage, value }) => (
+            <TableRow key={name} className="border-none bg-background hover:bg-background">
+              <TableHead className="h-6 w-[30%] max-w-60 min-w-35 p-0 pr-1 pb-1">
+                <div className="flex items-center gap-1">
+                  <span>{name}</span>
+                  {helpMessage != null && (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <Button variant="ghost" size="icon-xs">
+                            <CircleQuestionMark />
+                          </Button>
+                        }
+                      />
+                      <TooltipContent>
+                        <p>{helpMessage}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+              </TableHead>
+              <TableCell className="h-6 p-0 pb-1 wrap-break-word whitespace-normal">{value}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export default TimingsTab;

--- a/src/utils/time-utils.test.ts
+++ b/src/utils/time-utils.test.ts
@@ -2,15 +2,23 @@ import { describe, expect, it } from "vitest";
 import { formatDuration } from "./time-utils";
 
 describe("formatDuration", () => {
-  it("should return an empty string if the duration is not a number", () => {
+  it("should return the fallback string if the duration is undefined", () => {
+    expect(formatDuration(undefined)).toBe("");
+  });
+
+  it("should return the fallback string if the duration is null", () => {
+    expect(formatDuration(null)).toBe("");
+  });
+
+  it("should return the fallback string if the duration is not a number", () => {
     expect(formatDuration(NaN)).toBe("");
   });
 
-  it("should return an empty string if the duration is infinite", () => {
+  it("should return the fallback string if the duration is infinite", () => {
     expect(formatDuration(Infinity)).toBe("");
   });
 
-  it("should return an empty string if the duration is negative", () => {
+  it("should return the fallback string if the duration is negative", () => {
     expect(formatDuration(-1)).toBe("");
   });
 

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -10,12 +10,14 @@ const TIME_UNITS = [
  * Formats a duration.
  * @param value the duration to format (in milliseconds)
  * @param precision the number of decimal places to use (default: 2)
+ * @param fallback the fallback string to return if the duration is invalid (default: "")
  * @return the duration in a human-readable format
  */
-export function formatDuration(value: number, precision = 2): string {
-  if (Number.isNaN(value) || !Number.isFinite(value) || value < 0) {
-    return "";
+export function formatDuration(value: number | undefined | null, precision = 2, fallback = ""): string {
+  if (value == null || Number.isNaN(value) || !Number.isFinite(value) || value < 0) {
+    return fallback;
   }
+
   if (value === 0) {
     return "0 ms";
   }


### PR DESCRIPTION
## Changes

- Add tab in request details to get detailed timing info about the request/response round trip.

## Preview
![Preview](https://github.com/user-attachments/assets/7ad5254e-1258-4a24-9f6a-a6b97a88ac15)